### PR TITLE
adding kwargs to remove alpha channel

### DIFF
--- a/pdfplumber/display.py
+++ b/pdfplumber/display.py
@@ -17,13 +17,15 @@ DEFAULT_STROKE = COLORS.RED + (200,)
 DEFAULT_STROKE_WIDTH = 1
 DEFAULT_RESOLUTION = 72
 
-def get_page_image(pdf_path, page_no, resolution):
+def get_page_image(pdf_path, page_no, resolution, remove_alpha=True):
     """
     For kwargs, see http://docs.wand-py.org/en/latest/wand/image.html#wand.image.Image
     """
     page_path = "{0}[{1}]".format(pdf_path, page_no)
     with wand.image.Image(filename=page_path, resolution=resolution) as img:
-        with img.convert("png") as png:
+        if remove_alpha:
+            img.alpha_channel = 'remove'
+        with img.convert("jpg") as png:
             im = PIL.Image.open(BytesIO(png.make_blob()))
             if "transparency" in im.info:
                 converted = im.convert("RGBA").convert("RGB")
@@ -32,13 +34,14 @@ def get_page_image(pdf_path, page_no, resolution):
             return converted
 
 class PageImage(object):
-    def __init__(self, page, original=None, resolution=DEFAULT_RESOLUTION):
+    def __init__(self, page, remove_alpha=True, original=None, resolution=DEFAULT_RESOLUTION):
         self.page = page
         if original == None:
             self.original = get_page_image(
                 page.pdf.stream.name,
                 page.page_number - 1,
-                resolution
+                resolution,
+                remove_alpha
             )
         else:
             self.original = original

--- a/pdfplumber/display.py
+++ b/pdfplumber/display.py
@@ -23,9 +23,11 @@ def get_page_image(pdf_path, page_no, resolution, remove_alpha=True):
     """
     page_path = "{0}[{1}]".format(pdf_path, page_no)
     with wand.image.Image(filename=page_path, resolution=resolution) as img:
+        conv_type = 'png'
         if remove_alpha:
             img.alpha_channel = 'remove'
-        with img.convert("jpg") as png:
+            conv_type = 'jpg'
+        with img.convert(conv_type) as png:
             im = PIL.Image.open(BytesIO(png.make_blob()))
             if "transparency" in im.info:
                 converted = im.convert("RGBA").convert("RGB")

--- a/pdfplumber/display.py
+++ b/pdfplumber/display.py
@@ -17,7 +17,7 @@ DEFAULT_STROKE = COLORS.RED + (200,)
 DEFAULT_STROKE_WIDTH = 1
 DEFAULT_RESOLUTION = 72
 
-def get_page_image(pdf_path, page_no, resolution, remove_alpha=True):
+def get_page_image(pdf_path, page_no, resolution, remove_alpha=False):
     """
     For kwargs, see http://docs.wand-py.org/en/latest/wand/image.html#wand.image.Image
     """
@@ -36,7 +36,7 @@ def get_page_image(pdf_path, page_no, resolution, remove_alpha=True):
             return converted
 
 class PageImage(object):
-    def __init__(self, page, remove_alpha=True, original=None, resolution=DEFAULT_RESOLUTION):
+    def __init__(self, page, remove_alpha=False, original=None, resolution=DEFAULT_RESOLUTION):
         self.page = page
         if original == None:
             self.original = get_page_image(

--- a/pdfplumber/page.py
+++ b/pdfplumber/page.py
@@ -209,13 +209,13 @@ class Page(Container):
         filtered.bbox = self.bbox
         return filtered
 
-    def to_image(self, resolution=None):
+    def to_image(self, resolution=None, remove_alpha=True):
         """
         For conversion_kwargs, see http://docs.wand-py.org/en/latest/wand/image.html#wand.image.Image
         """
         from .display import PageImage, DEFAULT_RESOLUTION
         res = resolution or DEFAULT_RESOLUTION
-        return PageImage(self, resolution=res)
+        return PageImage(self, remove_alpha, resolution=res)
 
 class DerivedPage(Page):
     is_original = False

--- a/pdfplumber/page.py
+++ b/pdfplumber/page.py
@@ -209,7 +209,7 @@ class Page(Container):
         filtered.bbox = self.bbox
         return filtered
 
-    def to_image(self, resolution=None, remove_alpha=True):
+    def to_image(self, resolution=None, remove_alpha=False):
         """
         For conversion_kwargs, see http://docs.wand-py.org/en/latest/wand/image.html#wand.image.Image
         """


### PR DESCRIPTION
PR to enable removal of the alpha channel when rendering a PDF to image. The alpha channel is the pixel channel that determines transparency. 